### PR TITLE
fix: f2b is only 4 bytes wide

### DIFF
--- a/.github/workflows/telemetry-firmware.yaml
+++ b/.github/workflows/telemetry-firmware.yaml
@@ -63,7 +63,7 @@ jobs:
       - run: pip install -r requirements.txt
       - run: pip install -r ./tests/python/test-requirements.txt
       - run: pytest ./tests/python/integration.py # python tests
-      - run: make test && ./test # cpp tests
+      - run: make test # cpp tests
       - run: make coverage-html
       - uses: actions/upload-artifact@v3
         with:

--- a/car-bsp/DataModules/src/Mppt.cpp
+++ b/car-bsp/DataModules/src/Mppt.cpp
@@ -4,19 +4,14 @@
  *  Created on: Apr 17, 2023
  *      Author: Jack W
  */
+
+#include <cstring>
+
 #include "Mppt.hpp"
 #include "DataModuleInfo.hpp"
 
 namespace SolarGators::DataModules
 {
-
-union float2byte
-{
-	  float f;
-	  char  s[4];
-};
-
-float2byte f2b;
 
 enum {
 	MPPT0 = 1,
@@ -32,26 +27,18 @@ Mpptx0::Mpptx0(uint32_t can_id):
 
 void Mpptx0::ToByteArray(uint8_t* buff) const
 {
-	f2b.f = inputVoltage;
-	for (int i=0;i<=3;i++){
-		buff[i] = f2b.s[i];
-	}
-	f2b.f = inputCurrent;
-	for (int i=4;i<=7;i++){
-		buff[i] = f2b.s[i - 4];
-	}
+	size_t index = 0;
+	memcpy(buff + index, &inputVoltage, sizeof(inputVoltage));
+	index += sizeof(inputVoltage);
+	memcpy(buff + index, &inputCurrent, sizeof(inputCurrent));
 }
 
 void Mpptx0::FromByteArray(uint8_t* buff)
 {
-	for(int i=0;i<=3;i++){
-		f2b.s[i] = buff[i];
-	}
-	inputVoltage = f2b.f;
-	for(int i=4;i<=7;i++){
-		f2b.s[i - 4] = buff[i];
-	}
-	inputCurrent = f2b.f;
+  size_t index = 0;
+  memcpy(&inputVoltage, buff + index, sizeof(inputVoltage));
+  index += sizeof(inputVoltage);
+  memcpy(&inputCurrent, buff + index, sizeof(inputCurrent));
 }
 
 float Mpptx0::getInputVoltage() const {
@@ -94,26 +81,18 @@ Mpptx1::Mpptx1(uint32_t can_id): // INCREMENT BY 1 FROM MPPTx0
 
 void Mpptx1::ToByteArray(uint8_t* buff) const
 {
-	f2b.f = outputVoltage;
-	for (int i=0;i<=3;i++){
-		buff[i] = f2b.s[i];
-	}
-	f2b.f = outputCurrent;
-	for (int i=4;i<=7;i++){
-		buff[i] = f2b.s[i - 4];
-	}
+  size_t index = 0;
+  memcpy(buff + index, &outputVoltage, sizeof(outputVoltage));
+  index += sizeof(outputVoltage);
+  memcpy(buff + index, &outputCurrent, sizeof(outputCurrent));
 }
 
 void Mpptx1::FromByteArray(uint8_t* buff)
 {
-	for(int i=0;i<=3;i++){
-		f2b.s[i] = buff[i];
-	}
-	outputVoltage = f2b.f;
-	for(int i=4;i<=7;i++){
-		f2b.s[i - 4] = buff[i];
-	}
-	outputCurrent = f2b.f;
+  size_t index = 0;
+  memcpy(&outputVoltage, buff + index, sizeof(outputVoltage));
+  index += sizeof(outputVoltage);
+  memcpy(&outputCurrent, buff + index, sizeof(outputCurrent));
 }
 
 float Mpptx1::getOutputVoltage() const {
@@ -156,26 +135,18 @@ Mpptx2::Mpptx2(uint32_t can_id): // INCREMENT BY 2 FROM MPPTx0
 
 void Mpptx2::ToByteArray(uint8_t* buff) const
 {
-	f2b.f = mosfetTemp;
-	for (int i=0;i<=3;i++){
-		buff[i] = f2b.s[i];
-	}
-	f2b.f = controllerTemp;
-	for (int i=4;i<=7;i++){
-		buff[i] = f2b.s[i - 4];
-	}
+  size_t index = 0;
+  memcpy(buff + index, &mosfetTemp, sizeof(mosfetTemp));
+  index += sizeof(mosfetTemp);
+  memcpy(buff + index, &controllerTemp, sizeof(controllerTemp));
 }
 
 void Mpptx2::FromByteArray(uint8_t* buff)
 {
-	for(int i=0;i<=3;i++){
-		f2b.s[i] = buff[i];
-	}
-	mosfetTemp = f2b.f;
-	for(int i=4;i<=7;i++){
-		f2b.s[i - 4] = buff[i];
-	}
-	controllerTemp = f2b.f;
+  size_t index = 0;
+  memcpy(&mosfetTemp, buff + index, sizeof(mosfetTemp));
+  index += sizeof(mosfetTemp);
+  memcpy(&controllerTemp, buff + index, sizeof(controllerTemp));
 }
 
 float Mpptx2::getMosfetTemp() const {
@@ -218,26 +189,18 @@ Mpptx3::Mpptx3(uint32_t can_id): // INCREMENT BY 3 FROM MPPTx0
 
 void Mpptx3::ToByteArray(uint8_t* buff) const
 {
-	f2b.f = aux12V;
-	for (int i=0;i<=3;i++){
-		buff[i] = f2b.s[i];
-	}
-	f2b.f = aux3V;
-	for (int i=4;i<=7;i++){
-		buff[i] = f2b.s[i];
-	}
+  size_t index = 0;
+  memcpy(buff + index, &aux12V, sizeof(aux12V));
+  index += sizeof(aux12V);
+  memcpy(buff + index, &aux3V, sizeof(aux3V));
 }
 
 void Mpptx3::FromByteArray(uint8_t* buff)
 {
-	for(int i=0;i<=3;i++){
-		f2b.s[i] = buff[i];
-	}
-	aux12V = f2b.f;
-	for(int i=4;i<=7;i++){
-		f2b.s[i] = buff[i];
-	}
-	aux3V = f2b.f;
+  size_t index = 0;
+  memcpy(&aux12V, buff + index, sizeof(aux12V));
+  index += sizeof(aux12V);
+  memcpy(&aux3V, buff + index, sizeof(aux3V));
 }
 
 float Mpptx3::getAux12V() const {
@@ -280,26 +243,18 @@ Mpptx4::Mpptx4(uint32_t can_id): // INCREMENT BY 4 FROM MPPTx0
 
 void Mpptx4::ToByteArray(uint8_t* buff) const
 {
-	f2b.f = maxOutputVoltage;
-	for (int i=0;i<=3;i++){
-		buff[i] = f2b.s[i];
-	}
-	f2b.f = maxInputCurrent;
-	for (int i=4;i<=7;i++){
-		buff[i] = f2b.s[i - 4];
-	}
+  size_t index = 0;
+  memcpy(buff + index, &maxOutputVoltage, sizeof(maxOutputVoltage));
+  index += sizeof(maxOutputVoltage);
+  memcpy(buff + index, &maxInputCurrent, sizeof(maxInputCurrent));
 }
 
 void Mpptx4::FromByteArray(uint8_t* buff)
 {
-	for(int i=0;i<=3;i++){
-		f2b.s[i] = buff[i];
-	}
-	maxOutputVoltage = f2b.f;
-	for(int i=4;i<=7;i++){
-		f2b.s[i - 4] = buff[i];
-	}
-	maxInputCurrent = f2b.f;
+  size_t index = 0;
+  memcpy(&maxOutputVoltage, buff + index, sizeof(maxOutputVoltage));
+  index += sizeof(maxOutputVoltage);
+  memcpy(&maxInputCurrent, buff + index, sizeof(maxInputCurrent));
 }
 
 float Mpptx4::getMaxOutputVoltage() const {
@@ -518,30 +473,18 @@ Mpptx6::Mpptx6(uint32_t can_id): // INCREMENT BY 4 FROM MPPTx0
 
 void Mpptx6::ToByteArray(uint8_t* buff) const
 {
-	f2b.f = battOutVolt;
-	for (int i=0;i<=3;i++){
-		buff[i] = f2b.s[i];
-	}
-	f2b.f = powerConnTemp;
-	for (int i=4;i<=7;i++){
-		buff[i] = f2b.s[i - 4];
-	}
+  size_t index = 0;
+  memcpy(buff + index, &battOutVolt, sizeof(battOutVolt));
+  index += sizeof(battOutVolt);
+  memcpy(buff + index, &powerConnTemp, sizeof(powerConnTemp));
 }
 
 void Mpptx6::FromByteArray(uint8_t* buff)
 {
-	for(int i=0;i<=3;i++){
-		f2b.s[i] = buff[i];
-	}
-
-	battOutVolt = f2b.f;
-
-	for(int i=4;i<=7;i++){
-		f2b.s[i - 4] = buff[i];
-	}
-
-	powerConnTemp = f2b.f;
-
+  size_t index = 0;
+  memcpy(&battOutVolt, buff + index, sizeof(battOutVolt));
+  index += sizeof(battOutVolt);
+  memcpy(&powerConnTemp, buff + index, sizeof(powerConnTemp));
 }
 
 float Mpptx6::getBattOutVolt() const{

--- a/car-bsp/DataModules/src/Mppt.cpp
+++ b/car-bsp/DataModules/src/Mppt.cpp
@@ -38,7 +38,7 @@ void Mpptx0::ToByteArray(uint8_t* buff) const
 	}
 	f2b.f = inputCurrent;
 	for (int i=4;i<=7;i++){
-		buff[i] = f2b.s[i];
+		buff[i] = f2b.s[i - 4];
 	}
 }
 
@@ -49,7 +49,7 @@ void Mpptx0::FromByteArray(uint8_t* buff)
 	}
 	inputVoltage = f2b.f;
 	for(int i=4;i<=7;i++){
-		f2b.s[i] = buff[i];
+		f2b.s[i - 4] = buff[i];
 	}
 	inputCurrent = f2b.f;
 }
@@ -94,26 +94,26 @@ Mpptx1::Mpptx1(uint32_t can_id): // INCREMENT BY 1 FROM MPPTx0
 
 void Mpptx1::ToByteArray(uint8_t* buff) const
 {
-f2b.f = outputVoltage;
-for (int i=0;i<=3;i++){
-	buff[i] = f2b.s[i];
-}
-f2b.f = outputCurrent;
-for (int i=4;i<=7;i++){
-	buff[i] = f2b.s[i];
-}
+	f2b.f = outputVoltage;
+	for (int i=0;i<=3;i++){
+		buff[i] = f2b.s[i];
+	}
+	f2b.f = outputCurrent;
+	for (int i=4;i<=7;i++){
+		buff[i] = f2b.s[i - 4];
+	}
 }
 
 void Mpptx1::FromByteArray(uint8_t* buff)
 {
-for(int i=0;i<=3;i++){
-	f2b.s[i] = buff[i];
-}
-outputVoltage = f2b.f;
-for(int i=4;i<=7;i++){
-	f2b.s[i] = buff[i];
-}
-outputCurrent = f2b.f;
+	for(int i=0;i<=3;i++){
+		f2b.s[i] = buff[i];
+	}
+	outputVoltage = f2b.f;
+	for(int i=4;i<=7;i++){
+		f2b.s[i - 4] = buff[i];
+	}
+	outputCurrent = f2b.f;
 }
 
 float Mpptx1::getOutputVoltage() const {
@@ -162,7 +162,7 @@ void Mpptx2::ToByteArray(uint8_t* buff) const
 	}
 	f2b.f = controllerTemp;
 	for (int i=4;i<=7;i++){
-		buff[i] = f2b.s[i];
+		buff[i] = f2b.s[i - 4];
 	}
 }
 
@@ -173,7 +173,7 @@ void Mpptx2::FromByteArray(uint8_t* buff)
 	}
 	mosfetTemp = f2b.f;
 	for(int i=4;i<=7;i++){
-		f2b.s[i] = buff[i];
+		f2b.s[i - 4] = buff[i];
 	}
 	controllerTemp = f2b.f;
 }
@@ -286,7 +286,7 @@ void Mpptx4::ToByteArray(uint8_t* buff) const
 	}
 	f2b.f = maxInputCurrent;
 	for (int i=4;i<=7;i++){
-		buff[i] = f2b.s[i];
+		buff[i] = f2b.s[i - 4];
 	}
 }
 
@@ -297,7 +297,7 @@ void Mpptx4::FromByteArray(uint8_t* buff)
 	}
 	maxOutputVoltage = f2b.f;
 	for(int i=4;i<=7;i++){
-		f2b.s[i] = buff[i];
+		f2b.s[i - 4] = buff[i];
 	}
 	maxInputCurrent = f2b.f;
 }
@@ -393,8 +393,8 @@ void Mpptx5::FromByteArray(uint8_t* buff)
 	flag_duty_cycle_min		= buff[4] & (1 << 4);
 	flag_duty_cycle_max		= buff[4] & (1 << 5);
 	flag_local_mppt			= buff[4] & (1 << 6);
-	flag_global_mppt		= buff[4] & (1 << 7); 	
-	
+	flag_global_mppt		= buff[4] & (1 << 7);
+
 	mode = buff[5] & 0x1;
 	counter = buff[7];
 }
@@ -524,7 +524,7 @@ void Mpptx6::ToByteArray(uint8_t* buff) const
 	}
 	f2b.f = powerConnTemp;
 	for (int i=4;i<=7;i++){
-		buff[i] = f2b.s[i];
+		buff[i] = f2b.s[i - 4];
 	}
 }
 
@@ -537,7 +537,7 @@ void Mpptx6::FromByteArray(uint8_t* buff)
 	battOutVolt = f2b.f;
 
 	for(int i=4;i<=7;i++){
-		f2b.s[i] = buff[i];
+		f2b.s[i - 4] = buff[i];
 	}
 
 	powerConnTemp = f2b.f;

--- a/telemetry-collector/.gitignore
+++ b/telemetry-collector/.gitignore
@@ -1,7 +1,7 @@
 collector
-collector.dSYM
-test
-test.dSYM
+gps-test
+mppt-test
+*.dSYM
 *.gcno
 *.gcda
 *.gcov

--- a/telemetry-collector/Makefile
+++ b/telemetry-collector/Makefile
@@ -17,14 +17,17 @@ PROD_COMPIPE = $(BASE_COMPILE) src/main.cpp -o $(EXECUTABLE)
 all:
 	$(PROD_COMPIPE)
 
+.PHONY: gps-test
 gps-test:
 	$(BASE_COMPILE) tests/cpp/gps.cpp -o gps-test
 	./gps-test
 
+.PHONY: mppt-test
 mppt-test:
-	$(BASE_COMPILE) tests/cpp/gps.cpp -o mppt-test
+	$(BASE_COMPILE) tests/cpp/mppt.cpp -o mppt-test
 	./mppt-test
 
+.PHONY: test
 test: mppt-test gps-test
 
 

--- a/telemetry-collector/Makefile
+++ b/telemetry-collector/Makefile
@@ -17,9 +17,15 @@ PROD_COMPIPE = $(BASE_COMPILE) src/main.cpp -o $(EXECUTABLE)
 all:
 	$(PROD_COMPIPE)
 
-test:
-	$(BASE_COMPILE) tests/cpp/gps.cpp -o test
+gps-test:
+	$(BASE_COMPILE) tests/cpp/gps.cpp -o gps-test
+	./gps-test
 
+mppt-test:
+	$(BASE_COMPILE) tests/cpp/gps.cpp -o mppt-test
+	./mppt-test
+
+test: mppt-test gps-test
 
 
 coverage:

--- a/telemetry-collector/tests/cpp/gps.cpp
+++ b/telemetry-collector/tests/cpp/gps.cpp
@@ -66,6 +66,43 @@ int invalidTest() {
 }
 
 
+int emptyModule() {
+    // Test an empty module
+    SolarGators::DataModules::GPS GPS_Rx_0;
+
+    uint8_t buff2[100];
+    GPS_Rx_0.ToByteArray(buff2);
+
+    std::cout << "lat: " << GPS_Rx_0.getLatitude() << std::endl;
+    std::cout << "lo: " << GPS_Rx_0.getLongitude() << std::endl;
+    std::cout << "speed: " << GPS_Rx_0.getSpeed() << std::endl;
+    std::cout << "heading: " << GPS_Rx_0.getTrueCourse() << std::endl;
+    std::cout << "data: " << buff2 << std::endl;
+
+    if (strcmp(GPS_Rx_0.getLatitude(), "0")) {
+        std::cout << "Lat is incorrect!" << std::endl;
+        return -1;
+    }
+
+    if (strcmp(GPS_Rx_0.getLongitude(), "0")) {
+        std::cout << "Lat is incorrect!" << std::endl;
+        return -1;
+    }
+
+    if (strcmp(GPS_Rx_0.getSpeed(), "0")) {
+        std::cout << "Lat is incorrect!" << std::endl;
+        return -1;
+    }
+
+    if (strcmp(GPS_Rx_0.getTrueCourse(), "0")) {
+        std::cout << "Lat is incorrect!" << std::endl;
+        return -1;
+    }
+
+    return 0;
+}
+
+
 int main(int argc, char **argv) {
 
     std::cout << "Running Smoke Test.." << std::endl;
@@ -77,6 +114,13 @@ int main(int argc, char **argv) {
 
     std::cout << "Running Empty Test.." << std::endl;
     if (invalidTest() == -1) {
+        std::cout << "Failed!" << std::endl;
+        return -1;
+    }
+    std::cout << "Passed." << std::endl << std::endl;
+
+    std::cout << "Running Empty Module Test.." << std::endl;
+    if (emptyModule() == -1) {
         std::cout << "Failed!" << std::endl;
         return -1;
     }

--- a/telemetry-collector/tests/cpp/mppt.cpp
+++ b/telemetry-collector/tests/cpp/mppt.cpp
@@ -40,7 +40,7 @@ int smokeTest() {
         return -1;
     }
 
-    if (std::memcmp(data, result, 8)) {
+    if (memcmp(data, result, 8)) {
         std::cout << "ToByteArray output is not the same as the input!" << std::endl;
         return -1;
     }
@@ -75,7 +75,7 @@ int smokeTest() {
         return -1;
     }
 
-    if (std::memcmp(data, result, 8)) {
+    if (memcmp(data, result, 8)) {
         std::cout << "ToByteArray output is not the same as the input!" << std::endl;
         return -1;
     }

--- a/telemetry-collector/tests/cpp/mppt.cpp
+++ b/telemetry-collector/tests/cpp/mppt.cpp
@@ -1,6 +1,7 @@
 #include <map>
 #include <iostream>
 #include <sstream>
+#include <cstring>
 #include <csignal>
 #include "Mppt.hpp"
 
@@ -13,8 +14,8 @@ int smokeTest() {
     SolarGators::DataModules::Mpptx0 MPPT_Rx_0(0);
     float inputVoltage = 1.1;
     float inputCurrent = 2.2;
-    std::memcpy(&data[0], &inputVoltage, sizeof(inputVoltage));
-    std::memcpy(&data[4], &inputCurrent, sizeof(inputCurrent));
+    memcpy(&data[0], &inputVoltage, sizeof(inputVoltage));
+    memcpy(&data[4], &inputCurrent, sizeof(inputCurrent));
     MPPT_Rx_0.FromByteArray(data);
     MPPT_Rx_0.ToByteArray(result);
 
@@ -49,8 +50,8 @@ int smokeTest() {
     SolarGators::DataModules::Mpptx1 MPPT_Rx_1(0);
     float outputVoltage = 1.1;
     float outputCurrent = 2.2;
-    std::memcpy(&data[0], &outputVoltage, sizeof(outputVoltage));
-    std::memcpy(&data[4], &outputCurrent, sizeof(outputCurrent));
+    memcpy(&data[0], &outputVoltage, sizeof(outputVoltage));
+    memcpy(&data[4], &outputCurrent, sizeof(outputCurrent));
     MPPT_Rx_1.FromByteArray(data);
     MPPT_Rx_1.ToByteArray(result);
 

--- a/telemetry-collector/tests/cpp/mppt.cpp
+++ b/telemetry-collector/tests/cpp/mppt.cpp
@@ -1,0 +1,94 @@
+#include <map>
+#include <iostream>
+#include <sstream>
+#include <csignal>
+#include "Mppt.hpp"
+
+int smokeTest() {
+    uint8_t data[8];
+    uint8_t result[8];
+
+
+    std::cout << "MPPT_RX_0 Test" << std::endl;
+    SolarGators::DataModules::Mpptx0 MPPT_Rx_0(0);
+    float inputVoltage = 1.1;
+    float inputCurrent = 2.2;
+    std::memcpy(&data[0], &inputVoltage, sizeof(inputVoltage));
+    std::memcpy(&data[4], &inputCurrent, sizeof(inputCurrent));
+    MPPT_Rx_0.FromByteArray(data);
+    MPPT_Rx_0.ToByteArray(result);
+
+    std::cout << "input volt: " << MPPT_Rx_0.getInputVoltage() << std::endl;
+    std::cout << "input curr: " << MPPT_Rx_0.getInputCurrent() << std::endl;
+    for (int i = 0; i < 8; i++) {
+        printf("%02x ", data[i]);
+    }
+    std::cout << std::endl;
+    for (int i = 0; i < 8; i++) {
+        printf("%02x ", result[i]);
+    }
+    std::cout << std::endl;
+
+
+    if (MPPT_Rx_0.getInputVoltage() != inputVoltage) {
+        std::cout << "Input voltage is wrong!" << std::endl;
+        return -1;
+    }
+
+    if (MPPT_Rx_0.getInputCurrent() != inputCurrent) {
+        std::cout << "Input current is wrong!" << std::endl;
+        return -1;
+    }
+
+    if (std::memcmp(data, result, 8)) {
+        std::cout << "ToByteArray output is not the same as the input!" << std::endl;
+        return -1;
+    }
+
+    std::cout << std::endl << "MPPT_RX_1 Test" << std::endl;
+    SolarGators::DataModules::Mpptx1 MPPT_Rx_1(0);
+    float outputVoltage = 1.1;
+    float outputCurrent = 2.2;
+    std::memcpy(&data[0], &outputVoltage, sizeof(outputVoltage));
+    std::memcpy(&data[4], &outputCurrent, sizeof(outputCurrent));
+    MPPT_Rx_1.FromByteArray(data);
+    MPPT_Rx_1.ToByteArray(result);
+
+    std::cout << "output volt: " << MPPT_Rx_1.getOutputVoltage() << std::endl;
+    std::cout << "output curr: " << MPPT_Rx_1.getOutputCurrent() << std::endl;
+    for (int i = 0; i < 8; i++) {
+        printf("%02x ", data[i]);
+    }
+    std::cout << std::endl;
+    for (int i = 0; i < 8; i++) {
+        printf("%02x ", result[i]);
+    }
+    std::cout << std::endl;
+
+    if (MPPT_Rx_1.getOutputVoltage() != outputVoltage) {
+        std::cout << "Input voltage is wrong!" << std::endl;
+        return -1;
+    }
+
+    if (MPPT_Rx_1.getOutputCurrent() != outputCurrent) {
+        std::cout << "Input current is wrong!" << std::endl;
+        return -1;
+    }
+
+    if (std::memcmp(data, result, 8)) {
+        std::cout << "ToByteArray output is not the same as the input!" << std::endl;
+        return -1;
+    }
+
+    return 0;
+}
+
+
+int main(int argc, char **argv) {
+    std::cout << "Running Smoke Test.." << std::endl;
+    if (smokeTest() == -1) {
+        std::cout << "Failed!" << std::endl;
+        return -1;
+    }
+    std::cout << "Passed." << std::endl << std::endl;
+}


### PR DESCRIPTION
I noticed the output voltage and input voltage are the same on the UI:
<img width="618" alt="Screenshot 2023-06-18 at 9 34 27 AM" src="https://github.com/Solar-Gators/Sunrider-Firmware/assets/7267438/12ca0ff1-f944-4cc4-ba36-c8544f590582">



After inspecting the code I noticed we forgot to adjust the index for the f2b byte array. I added some tests to verify that this is working :)