### PR TITLE
add crc for validating messages

### DIFF
--- a/.github/workflows/telemetry-firmware.yaml
+++ b/.github/workflows/telemetry-firmware.yaml
@@ -115,7 +115,9 @@ jobs:
       - name: Comment out files that renode doesn't mock properly
         run: |
           sed -i 's/SystemClock_Config();/\/\/SystemClock_Config();/' Core/Src/main.c && \
-          sed -i 's/MX_CAN_Init();/\/\/MX_CAN_Init();/' Core/Src/main.c
+          sed -i 's/MX_CAN_Init();/\/\/MX_CAN_Init();/' Core/Src/main.c && \
+          sed -i 's/osTimerStart(can_tx_timer_id, 2000);/\/\/osTimerStart(can_tx_timer_id, 2000);/' Core/Src/user.cpp && \
+          sed -i 's/osTimerStart(gps_poll_timer_id, 10);/\/\/osTimerStart(gps_poll_timer_id, 10);/' Core/Src/user.cpp
 
       # Need to rebuild with modified code
       - uses: Solar-Gators/STM32-Infrastructure@main

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,14 @@
 {
     "files.associations": {
-        "functional": "cpp"
+        "functional": "cpp",
+        "__hash_table": "cpp",
+        "__split_buffer": "cpp",
+        "__tree": "cpp",
+        "array": "cpp",
+        "bitset": "cpp",
+        "initializer_list": "cpp",
+        "map": "cpp",
+        "unordered_map": "cpp",
+        "vector": "cpp"
     }
 }

--- a/car-bsp/Helpers/inc/crc16.hpp
+++ b/car-bsp/Helpers/inc/crc16.hpp
@@ -1,0 +1,19 @@
+/*
+ * crc16.hpp
+ *
+ *  Created on: Jun 20, 2023
+ *      Author: Raymond Bernardo
+ */
+
+#ifndef SOLARGATORSBSP_HELPERS_CRC16
+#define SOLARGATORSBSP_HELPERS_CRC16
+
+#include <cstdint>
+
+namespace SolarGators::Helpers {
+
+uint16_t crc16(uint8_t* data_p, uint32_t length);
+
+}
+
+#endif /* SOLARGATORSBSP_HELPERS_CRC16 */

--- a/car-bsp/Helpers/src/crc16.cpp
+++ b/car-bsp/Helpers/src/crc16.cpp
@@ -1,0 +1,24 @@
+/*
+ * crc16.cpp
+ *
+ *  Created on: Jun 20, 2023
+ *      Author: Raymond Bernardo
+ */
+
+#include "crc16.hpp"
+
+namespace SolarGators::Helpers {
+
+uint16_t crc16(uint8_t* data_p, uint32_t length) {
+    uint8_t x;
+    uint16_t crc = 0xFFFF;
+
+    while (length--){
+        x = crc >> 8 ^ *data_p++;
+        x ^= x>>4;
+        crc = (crc << 8) ^ ((uint16_t)(x << 12)) ^ ((uint16_t)(x <<5)) ^ ((uint16_t)x);
+    }
+    return crc;
+}
+
+}

--- a/front-lights-firmware/.cproject
+++ b/front-lights-firmware/.cproject
@@ -75,6 +75,7 @@
 									<listOptionValue builtIn="false" value="../../car-bsp/Drivers/inc"/>
 									<listOptionValue builtIn="false" value="../../car-bsp/DataModules/inc"/>
 									<listOptionValue builtIn="false" value="../../car-bsp/etl/include"/>
+									<listOptionValue builtIn="false" value="../../car-bsp/Helpers/inc"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.2031096446" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
 							</tool>

--- a/rear-lights-firmware/.cproject
+++ b/rear-lights-firmware/.cproject
@@ -77,6 +77,7 @@
 									<listOptionValue builtIn="false" value="../../car-bsp/Drivers/inc"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/RearLightsFirmware/Drivers/BSP/Components/lsm6dsr}&quot;"/>
 									<listOptionValue builtIn="false" value="../Drivers/BSP/Components/lsm6dsr"/>
+									<listOptionValue builtIn="false" value="../../car-bsp/Helpers/inc"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.767909644" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
 							</tool>

--- a/steering-firmware/.cproject
+++ b/steering-firmware/.cproject
@@ -76,6 +76,7 @@
 									<listOptionValue builtIn="false" value="../../car-bsp/DataModules/inc"/>
 									<listOptionValue builtIn="false" value="../../car-bsp/etl/include"/>
 									<listOptionValue builtIn="false" value="../../car-bsp/Drivers/inc"/>
+									<listOptionValue builtIn="false" value="../../car-bsp/Helpers/inc"/>
 								</option>
 								<option id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard.1538593893" name="Language standard" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard" useByScannerDiscovery="true" value="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.option.languagestandard.value.gnupp14" valueType="enumerated"/>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.785566308" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>

--- a/telemetry-collector/Makefile
+++ b/telemetry-collector/Makefile
@@ -1,8 +1,10 @@
 CPP_FILES = src/lib/*.cpp
 CPP_FILES += ../car-bsp/DataModules/src/*.cpp
+CPP_FILES += ../car-bsp/Helpers/src/*.cpp
 
 CPP_INCLUDES = -I ../car-bsp/DataModules/inc
 CPP_INCLUDES += -I ../car-bsp/etl/incude
+CPP_INCLUDES += -I ../car-bsp/Helpers/inc
 CPP_INCLUDES += -I ./src/lib/inc
 
 

--- a/telemetry-collector/src/lib/NetworkReceive.cpp
+++ b/telemetry-collector/src/lib/NetworkReceive.cpp
@@ -4,5 +4,6 @@ void NetworkReceive::fromByteArray(u_int8_t *buff) {
     this->can_id = (int)buff[3] | ((int)buff[2] << 8) | ((int)buff[1] << 16) | ((int)buff[0] << 24);
     this->instance_id = buff[4];
     this->size = buff[5];
-    this->data = &buff[6];
+    this->crc = (int)buff[7] | ((int)buff[6] << 8);
+    this->data = &buff[8];
 }

--- a/telemetry-collector/src/lib/inc/NetworkReceive.hpp
+++ b/telemetry-collector/src/lib/inc/NetworkReceive.hpp
@@ -2,10 +2,11 @@
 
 class NetworkReceive {
     public:
-        u_int32_t can_id;
-        u_int16_t instance_id;
-        u_int16_t size;
-        u_int8_t *data;
+        uint32_t can_id;
+        uint16_t instance_id;
+        uint16_t size;
+        uint16_t crc;
+        uint8_t *data;
 
         void fromByteArray(u_int8_t *buff);
 };

--- a/telemetry-collector/src/lib/inc/NetworkReceive.hpp
+++ b/telemetry-collector/src/lib/inc/NetworkReceive.hpp
@@ -2,11 +2,11 @@
 
 class NetworkReceive {
     public:
-        uint32_t can_id;
-        uint16_t instance_id;
-        uint16_t size;
-        uint16_t crc;
-        uint8_t *data;
+        u_int32_t can_id;
+        u_int16_t instance_id;
+        u_int16_t size;
+        u_int16_t crc;
+        u_int8_t *data;
 
         void fromByteArray(u_int8_t *buff);
 };

--- a/telemetry-collector/src/main.cpp
+++ b/telemetry-collector/src/main.cpp
@@ -13,6 +13,8 @@
 #include "DataModuleInfo.hpp"
 #include "Mppt.hpp"
 #include "GPS.hpp"
+#include "crc16.hpp"
+#include "Logger.hpp"
 
 SolarGators::DataModules::GPS GPS_Rx_0;
 
@@ -99,6 +101,12 @@ int main(int argc, char *argv[]) {
             continue;
         }
         network.fromByteArray(dataLink.buffer);
+        uint16_t crc = SolarGators::Helpers::crc16(network.data, network.size);
+        if (crc != network.crc) {
+            Logger::info("Error: CRC did not match, skipping.\n");
+            continue;
+        }
+
         //Get module
         if (modules.count(network.can_id) > 0) {
             SolarGators::DataModules::DataModule* rx_module = (*modules.find(network.can_id)).second;

--- a/telemetry-firmware/.cproject
+++ b/telemetry-firmware/.cproject
@@ -78,6 +78,7 @@
 									<listOptionValue builtIn="false" value="../Drivers/CMSIS/Device/ST/STM32F0xx/Include"/>
 									<listOptionValue builtIn="false" value="../Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2"/>
 									<listOptionValue builtIn="false" value="../Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_CM0"/>
+									<listOptionValue builtIn="false" value="../../car-bsp/Helpers/inc"/>
 								</option>
 								<inputType id="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp.1264479682" superClass="com.st.stm32cube.ide.mcu.gnu.managedbuild.tool.cpp.compiler.input.cpp"/>
 							</tool>


### PR DESCRIPTION
I'm using a crc16 checksum that was generated from chatGPT, but its basically identical to this implementation: https://stackoverflow.com/a/23726131/8082502

Before we send out a message we calculate and include a crc of the data, when we recieve a message on telemetry-collector we compare crcs and throw out the message if it doesn't match.

Next steps would be creating an endpoint on Pit-GUI to track the number of transmission errors.